### PR TITLE
feat(gpt,mbr,pipeline): decouple partition LBA size from upstream chunk size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 [workspace.package]
 version = "0.0.1"
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.88"
 license = "GPL-3.0-only"
 repository = "https://github.com/samcday/gibblox"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 version = "0.0.1"
 edition = "2024"
 rust-version = "1.88"
-license = "GPL-3.0-only"
+license = "GPL-3.0-or-later"
 repository = "https://github.com/samcday/gibblox"
 
 [workspace.lints.clippy]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/crates/gibblox-android-sparse/src/lib.rs
+++ b/crates/gibblox-android-sparse/src/lib.rs
@@ -179,8 +179,7 @@ where
             return Err(GibbloxError::with_message(
                 GibbloxErrorKind::InvalidInput,
                 format!(
-                    "declared sparse chunk count {} exceeds maximum {} for available bytes",
-                    total_chunks_u64, max_chunk_headers
+                    "declared sparse chunk count {total_chunks_u64} exceeds maximum {max_chunk_headers} for available bytes"
                 ),
             ));
         }
@@ -510,8 +509,7 @@ where
             return Err(GibbloxError::with_message(
                 GibbloxErrorKind::InvalidInput,
                 format!(
-                    "sparse index output size mismatch (mapped {}, expected {})",
-                    output_cursor, expanded_size_bytes
+                    "sparse index output size mismatch (mapped {output_cursor}, expected {expanded_size_bytes})"
                 ),
             ));
         }

--- a/crates/gibblox-core/src/gpt.rs
+++ b/crates/gibblox-core/src/gpt.rs
@@ -160,12 +160,6 @@ impl GptBlockReader {
         }
 
         let upstream_total_blocks = source.total_blocks().await?;
-        if upstream_total_blocks < 2 {
-            return Err(GibbloxError::with_message(
-                GibbloxErrorKind::InvalidInput,
-                "GPT image requires at least two logical blocks",
-            ));
-        }
         let source_size_bytes = upstream_total_blocks
             .checked_mul(upstream_block_size as u64)
             .ok_or_else(|| {
@@ -192,7 +186,7 @@ impl GptBlockReader {
             )
         };
         let source_block_size = effective_lba_size;
-        let source_total_blocks = source_size_bytes / (effective_lba_size as u64);
+        let source_total_blocks = source.total_blocks().await?;
         if source_total_blocks < 2 {
             return Err(GibbloxError::with_message(
                 GibbloxErrorKind::InvalidInput,
@@ -1199,6 +1193,29 @@ mod tests {
         .expect("auto-probe should locate GPT at 512-byte LBAs");
 
         assert_eq!(gpt.partition_partuuid(), TEST_PART1_UUID);
+        let mut first = vec![0u8; 1024];
+        block_on(gpt.read_blocks(0, &mut first, ReadContext::FOREGROUND)).expect("read first");
+        assert_eq!(&first[..], &partition_one_data[..1024]);
+    }
+
+    #[test]
+    fn gpt_reader_accepts_single_upstream_block_with_explicit_source_lba_size() {
+        let (disk, partition_one_data) = build_test_gpt_disk();
+        let disk_size = disk.len() as u64;
+        let inner = FakeReader {
+            block_size: TEST_BLOCK_SIZE as u32,
+            data: disk,
+        };
+        let upstream = block_on(WindowBlockReader::new(inner, 0, disk_size, 131072))
+            .expect("create single-block upstream view");
+
+        let config =
+            GptBlockReaderConfig::new(GptPartitionSelector::part_uuid(TEST_PART1_UUID), 1024)
+                .with_source_lba_size(512);
+
+        let gpt = block_on(GptBlockReader::open_with_config(upstream, config))
+            .expect("single-upstream-block source must not be rejected before LBA remap");
+
         let mut first = vec![0u8; 1024];
         block_on(gpt.read_blocks(0, &mut first, ReadContext::FOREGROUND)).expect("read first");
         assert_eq!(&first[..], &partition_one_data[..1024]);

--- a/crates/gibblox-core/src/gpt.rs
+++ b/crates/gibblox-core/src/gpt.rs
@@ -1,8 +1,9 @@
 extern crate alloc;
 
-use alloc::{boxed::Box, format, string::String, sync::Arc, vec};
+use alloc::{boxed::Box, format, string::String, sync::Arc, vec, vec::Vec};
 use async_trait::async_trait;
 use core::fmt;
+use core::fmt::Write as _;
 use tracing::{info, trace};
 
 use crate::{
@@ -51,6 +52,15 @@ pub struct GptBlockReaderConfig {
     pub selector: GptPartitionSelector,
     pub block_size: u32,
     pub source_identity: Option<String>,
+    /// LBA size, in bytes, to address the upstream source as when locating the GPT.
+    ///
+    /// `None` enables auto-probe: the reader tries the upstream's reported
+    /// `block_size()`, then 512, then 4096, and uses the first one whose LBA1
+    /// contains a valid `EFI PART` signature. Set this explicitly when the
+    /// upstream source reports a `block_size()` that does not match the LBA
+    /// size the contained image was formatted with (e.g. a 4096-byte-chunked
+    /// Android sparse image whose contained disk uses 512-byte sectors).
+    pub source_lba_size: Option<u32>,
 }
 
 impl GptBlockReaderConfig {
@@ -59,6 +69,7 @@ impl GptBlockReaderConfig {
             selector,
             block_size,
             source_identity: None,
+            source_lba_size: None,
         }
     }
 
@@ -67,11 +78,24 @@ impl GptBlockReaderConfig {
         self
     }
 
+    pub fn with_source_lba_size(mut self, source_lba_size: u32) -> Self {
+        self.source_lba_size = Some(source_lba_size);
+        self
+    }
+
     fn validate(&self) -> GibbloxResult<()> {
         if self.block_size == 0 || !self.block_size.is_power_of_two() {
             return Err(GibbloxError::with_message(
                 GibbloxErrorKind::InvalidInput,
                 "block size must be non-zero power of two",
+            ));
+        }
+        if let Some(sz) = self.source_lba_size
+            && (sz == 0 || !sz.is_power_of_two())
+        {
+            return Err(GibbloxError::with_message(
+                GibbloxErrorKind::InvalidInput,
+                "source_lba_size must be non-zero power of two",
             ));
         }
         Ok(())
@@ -90,7 +114,11 @@ impl BlockReaderConfigIdentity for GptBlockReaderConfig {
             out,
             "):selector={}:block_size={}",
             self.selector, self.block_size
-        )
+        )?;
+        if let Some(sz) = self.source_lba_size {
+            write!(out, ":source_lba_size={sz}")?;
+        }
+        Ok(())
     }
 }
 
@@ -116,35 +144,63 @@ impl GptBlockReader {
         config: GptBlockReaderConfig,
     ) -> GibbloxResult<Self> {
         config.validate()?;
-        info!(selector = %config.selector, block_size = config.block_size, "constructing GPT-backed reader");
+        info!(
+            selector = %config.selector,
+            block_size = config.block_size,
+            source_lba_size = ?config.source_lba_size,
+            "constructing GPT-backed reader"
+        );
 
-        let source_block_size = source.block_size();
-        if source_block_size == 0 || !source_block_size.is_power_of_two() {
+        let upstream_block_size = source.block_size();
+        if upstream_block_size == 0 || !upstream_block_size.is_power_of_two() {
             return Err(GibbloxError::with_message(
                 GibbloxErrorKind::InvalidInput,
                 "source block size must be non-zero power of two",
             ));
         }
 
-        let source_total_blocks = source.total_blocks().await?;
-        if source_total_blocks < 2 {
+        let upstream_total_blocks = source.total_blocks().await?;
+        if upstream_total_blocks < 2 {
             return Err(GibbloxError::with_message(
                 GibbloxErrorKind::InvalidInput,
                 "GPT image requires at least two logical blocks",
             ));
         }
-        let source_size_bytes = source_total_blocks
-            .checked_mul(source_block_size as u64)
+        let source_size_bytes = upstream_total_blocks
+            .checked_mul(upstream_block_size as u64)
             .ok_or_else(|| {
                 GibbloxError::with_message(GibbloxErrorKind::OutOfRange, "image size overflow")
             })?;
 
-        let source: Arc<dyn BlockReader> = Arc::new(source);
-        let source_identity = config
+        let upstream: Arc<dyn BlockReader> = Arc::new(source);
+        let upstream_identity = config
             .source_identity
             .clone()
-            .unwrap_or_else(|| crate::block_identity_string(source.as_ref()));
-        let config = config.with_source_identity(source_identity);
+            .unwrap_or_else(|| crate::block_identity_string(upstream.as_ref()));
+
+        let effective_lba_size = if let Some(sz) = config.source_lba_size {
+            sz
+        } else {
+            probe_gpt_source_lba_size(&upstream, source_size_bytes).await?
+        };
+
+        let source: Arc<dyn BlockReader> = if effective_lba_size == upstream_block_size {
+            upstream
+        } else {
+            Arc::new(
+                WindowBlockReader::new(upstream, 0, source_size_bytes, effective_lba_size).await?,
+            )
+        };
+        let source_block_size = effective_lba_size;
+        let source_total_blocks = source_size_bytes / (effective_lba_size as u64);
+        if source_total_blocks < 2 {
+            return Err(GibbloxError::with_message(
+                GibbloxErrorKind::InvalidInput,
+                "GPT image requires at least two logical blocks at the chosen LBA size",
+            ));
+        }
+
+        let config = config.with_source_identity(upstream_identity);
 
         let mut header_block = vec![0u8; source_block_size as usize];
         read_source_blocks_exact(
@@ -381,6 +437,72 @@ impl GptPartitionEntry {
             GibbloxError::with_message(GibbloxErrorKind::OutOfRange, "partition size overflow")
         })
     }
+}
+
+async fn probe_gpt_source_lba_size(
+    source: &Arc<dyn BlockReader>,
+    source_size_bytes: u64,
+) -> GibbloxResult<u32> {
+    let upstream_size = source.block_size();
+    let mut candidates: Vec<u32> = Vec::new();
+    if upstream_size > 0 && upstream_size.is_power_of_two() {
+        candidates.push(upstream_size);
+    }
+    for &cand in &[512u32, 4096] {
+        if !candidates.contains(&cand) {
+            candidates.push(cand);
+        }
+    }
+
+    for &candidate in &candidates {
+        let needed = match (candidate as u64).checked_mul(2) {
+            Some(value) => value,
+            None => continue,
+        };
+        if needed > source_size_bytes {
+            continue;
+        }
+
+        let mut header = vec![0u8; candidate as usize];
+        let probe_result = if candidate == upstream_size {
+            source
+                .read_blocks(1, &mut header, ReadContext::FOREGROUND)
+                .await
+                .map(|_| ())
+        } else {
+            match WindowBlockReader::new(Arc::clone(source), 0, source_size_bytes, candidate).await
+            {
+                Ok(view) => view
+                    .read_blocks(1, &mut header, ReadContext::FOREGROUND)
+                    .await
+                    .map(|_| ()),
+                Err(err) => Err(err),
+            }
+        };
+
+        if probe_result.is_ok() && header.len() >= 8 && &header[..8] == GPT_SIGNATURE {
+            info!(
+                lba_size = candidate,
+                "auto-probed GPT source LBA size from EFI PART signature"
+            );
+            return Ok(candidate);
+        }
+    }
+
+    let mut tried = String::new();
+    for (i, c) in candidates.iter().enumerate() {
+        if i > 0 {
+            tried.push_str(", ");
+        }
+        let _ = write!(tried, "{c}");
+    }
+    Err(GibbloxError::with_message(
+        GibbloxErrorKind::InvalidInput,
+        format!(
+            "GPT header signature not found at LBA1 for any candidate LBA size (tried: {tried}); \
+             set `lba_size:` on the gpt source if your image uses a different sector size"
+        ),
+    ))
 }
 
 async fn read_source_blocks_exact(
@@ -1056,6 +1178,120 @@ mod tests {
             Err(err) => err,
         };
         assert_eq!(err.kind(), GibbloxErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn gpt_reader_auto_probes_when_upstream_misreports_block_size() {
+        let (disk, partition_one_data) = build_test_gpt_disk();
+        let disk_size = disk.len() as u64;
+        let inner = FakeReader {
+            block_size: TEST_BLOCK_SIZE as u32,
+            data: disk,
+        };
+        let upstream = block_on(WindowBlockReader::new(inner, 0, disk_size, 4096))
+            .expect("create misreporting 4096 view");
+
+        let gpt = block_on(GptBlockReader::new(
+            upstream,
+            GptPartitionSelector::part_uuid(TEST_PART1_UUID),
+            1024,
+        ))
+        .expect("auto-probe should locate GPT at 512-byte LBAs");
+
+        assert_eq!(gpt.partition_partuuid(), TEST_PART1_UUID);
+        let mut first = vec![0u8; 1024];
+        block_on(gpt.read_blocks(0, &mut first, ReadContext::FOREGROUND)).expect("read first");
+        assert_eq!(&first[..], &partition_one_data[..1024]);
+    }
+
+    #[test]
+    fn gpt_reader_explicit_source_lba_size_wins() {
+        let (disk, partition_one_data) = build_test_gpt_disk();
+        let disk_size = disk.len() as u64;
+        let inner = FakeReader {
+            block_size: TEST_BLOCK_SIZE as u32,
+            data: disk,
+        };
+        let upstream = block_on(WindowBlockReader::new(inner, 0, disk_size, 4096))
+            .expect("create misreporting 4096 view");
+
+        let config =
+            GptBlockReaderConfig::new(GptPartitionSelector::part_uuid(TEST_PART1_UUID), 1024)
+                .with_source_lba_size(512);
+
+        let gpt = block_on(GptBlockReader::open_with_config(upstream, config))
+            .expect("explicit source_lba_size should locate GPT");
+
+        let mut first = vec![0u8; 1024];
+        block_on(gpt.read_blocks(0, &mut first, ReadContext::FOREGROUND)).expect("read first");
+        assert_eq!(&first[..], &partition_one_data[..1024]);
+    }
+
+    #[test]
+    fn gpt_reader_probe_error_lists_candidates() {
+        let mut disk = vec![0u8; TEST_BLOCK_SIZE * TEST_TOTAL_BLOCKS];
+        for (idx, byte) in disk.iter_mut().enumerate() {
+            *byte = (idx % 251) as u8;
+        }
+        let reader = FakeReader {
+            block_size: TEST_BLOCK_SIZE as u32,
+            data: disk,
+        };
+
+        let err = match block_on(GptBlockReader::new(
+            reader,
+            GptPartitionSelector::index(0),
+            TEST_BLOCK_SIZE as u32,
+        )) {
+            Ok(_) => panic!("probe with no signature should fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), GibbloxErrorKind::InvalidInput);
+        let msg = format!("{err}");
+        assert!(msg.contains("512"), "error message should mention 512: {msg}");
+        assert!(
+            msg.contains("4096"),
+            "error message should mention 4096: {msg}"
+        );
+        assert!(
+            msg.contains("lba_size"),
+            "error message should mention lba_size knob: {msg}"
+        );
+    }
+
+    #[test]
+    fn gpt_reader_rejects_invalid_explicit_source_lba_size() {
+        let (disk, _) = build_test_gpt_disk();
+        let reader = FakeReader {
+            block_size: TEST_BLOCK_SIZE as u32,
+            data: disk,
+        };
+        let config = GptBlockReaderConfig::new(GptPartitionSelector::index(0), 512)
+            .with_source_lba_size(513);
+
+        let err = match block_on(GptBlockReader::open_with_config(reader, config)) {
+            Ok(_) => panic!("non-pow2 source_lba_size should fail validate"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), GibbloxErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn gpt_reader_config_identity_includes_source_lba_size() {
+        let plain = GptBlockReaderConfig::new(GptPartitionSelector::index(0), 512)
+            .with_source_identity("upstream");
+        let mut s_plain = String::new();
+        plain.write_identity(&mut s_plain).unwrap();
+
+        let with_lba = GptBlockReaderConfig::new(GptPartitionSelector::index(0), 512)
+            .with_source_identity("upstream")
+            .with_source_lba_size(4096);
+        let mut s_with = String::new();
+        with_lba.write_identity(&mut s_with).unwrap();
+
+        assert_ne!(s_plain, s_with);
+        assert!(s_with.contains("source_lba_size=4096"));
+        assert!(!s_plain.contains("source_lba_size"));
     }
 
     #[test]

--- a/crates/gibblox-core/src/gpt.rs
+++ b/crates/gibblox-core/src/gpt.rs
@@ -1265,7 +1265,10 @@ mod tests {
         };
         assert_eq!(err.kind(), GibbloxErrorKind::InvalidInput);
         let msg = format!("{err}");
-        assert!(msg.contains("512"), "error message should mention 512: {msg}");
+        assert!(
+            msg.contains("512"),
+            "error message should mention 512: {msg}"
+        );
         assert!(
             msg.contains("4096"),
             "error message should mention 4096: {msg}"

--- a/crates/gibblox-core/src/lib.rs
+++ b/crates/gibblox-core/src/lib.rs
@@ -19,7 +19,7 @@ mod window_block;
 
 pub use block_byte::BlockByteReader;
 pub use byte_range::AlignedByteReader;
-pub use gpt::{GptBlockReader, GptPartitionSelector};
+pub use gpt::{GptBlockReader, GptBlockReaderConfig, GptPartitionSelector};
 pub use lru::{LruBlockReader, LruConfig};
 pub use offset_byte::OffsetByteReader;
 pub use paged::{PagedBlockConfig, PagedBlockReader};

--- a/crates/gibblox-mbr/src/lib.rs
+++ b/crates/gibblox-mbr/src/lib.rs
@@ -62,6 +62,16 @@ pub struct MbrBlockReaderConfig {
     pub selector: MbrPartitionSelector,
     pub block_size: u32,
     pub source_identity: Option<String>,
+    /// LBA size, in bytes, that MBR partition `first_lba` / `sector_count`
+    /// values should be interpreted in.
+    ///
+    /// When `None` (the default), entries are interpreted as 512-byte LBAs —
+    /// the MBR convention and what virtually every legacy MBR-formatted disk
+    /// uses. Set this explicitly when targeting a non-standard layout (for
+    /// example a >2 TiB MBR using 4096-byte LBAs, or an encoded source whose
+    /// reported `block_size()` does not match the contained image's true LBA
+    /// size). A future revision may auto-probe the value.
+    pub source_lba_size: Option<u32>,
 }
 
 impl MbrBlockReaderConfig {
@@ -70,6 +80,7 @@ impl MbrBlockReaderConfig {
             selector,
             block_size,
             source_identity: None,
+            source_lba_size: None,
         }
     }
 
@@ -78,11 +89,24 @@ impl MbrBlockReaderConfig {
         self
     }
 
+    pub fn with_source_lba_size(mut self, source_lba_size: u32) -> Self {
+        self.source_lba_size = Some(source_lba_size);
+        self
+    }
+
     fn validate(&self) -> GibbloxResult<()> {
         if self.block_size == 0 || !self.block_size.is_power_of_two() {
             return Err(GibbloxError::with_message(
                 GibbloxErrorKind::InvalidInput,
                 "block size must be non-zero power of two",
+            ));
+        }
+        if let Some(sz) = self.source_lba_size
+            && (sz == 0 || !sz.is_power_of_two())
+        {
+            return Err(GibbloxError::with_message(
+                GibbloxErrorKind::InvalidInput,
+                "source_lba_size must be non-zero power of two",
             ));
         }
         Ok(())
@@ -101,7 +125,11 @@ impl BlockReaderConfigIdentity for MbrBlockReaderConfig {
             out,
             "):selector={}:block_size={}",
             self.selector, self.block_size
-        )
+        )?;
+        if let Some(sz) = self.source_lba_size {
+            write!(out, ":source_lba_size={sz}")?;
+        }
+        Ok(())
     }
 }
 
@@ -166,8 +194,10 @@ impl MbrBlockReader {
         let disk_signature = mbr_disk_signature(&header);
 
         let selected = select_partition_entry(&header, &config.selector)?;
+        let effective_lba_size =
+            u64::from(config.source_lba_size.unwrap_or(MBR_SECTOR_SIZE as u32));
         let partition_offset_bytes = u64::from(selected.first_lba)
-            .checked_mul(MBR_SECTOR_SIZE as u64)
+            .checked_mul(effective_lba_size)
             .ok_or_else(|| {
                 GibbloxError::with_message(
                     GibbloxErrorKind::OutOfRange,
@@ -175,7 +205,7 @@ impl MbrBlockReader {
                 )
             })?;
         let partition_size_bytes = u64::from(selected.sector_count)
-            .checked_mul(MBR_SECTOR_SIZE as u64)
+            .checked_mul(effective_lba_size)
             .ok_or_else(|| {
                 GibbloxError::with_message(GibbloxErrorKind::OutOfRange, "partition size overflow")
             })?;
@@ -612,6 +642,75 @@ mod tests {
             Err(err) => err,
         };
         assert_eq!(err.kind(), GibbloxErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn mbr_reader_explicit_source_lba_size_addresses_4k_layout() {
+        const LBA_SIZE: usize = 4096;
+        const TOTAL_LBAS: usize = 16;
+        let mut disk = vec![0u8; LBA_SIZE * TOTAL_LBAS];
+
+        disk[MBR_DISK_SIGNATURE_OFFSET..MBR_DISK_SIGNATURE_OFFSET + 4]
+            .copy_from_slice(&TEST_DISK_SIGNATURE.to_le_bytes());
+        disk[MBR_SIGNATURE_OFFSET..MBR_SIGNATURE_OFFSET + 2].copy_from_slice(&MBR_SIGNATURE);
+        write_partition_entry(&mut disk, 0, 0x80, 0x83, 2, 3);
+
+        let partition_data: alloc::vec::Vec<u8> =
+            (0..(LBA_SIZE * 3)).map(|idx| (idx % 251) as u8).collect();
+        let partition_offset = 2 * LBA_SIZE;
+        disk[partition_offset..partition_offset + partition_data.len()]
+            .copy_from_slice(&partition_data);
+
+        let reader = FakeReader {
+            block_size: LBA_SIZE as u32,
+            data: disk,
+        };
+        let config =
+            MbrBlockReaderConfig::new(MbrPartitionSelector::part_uuid(TEST_PART1_UUID), 4096)
+                .with_source_lba_size(LBA_SIZE as u32);
+
+        let mbr = block_on(MbrBlockReader::open_with_config(reader, config))
+            .expect("explicit 4096 source_lba_size should locate partition");
+
+        assert_eq!(mbr.partition_size_bytes(), (LBA_SIZE * 3) as u64);
+        let mut out = vec![0u8; LBA_SIZE];
+        block_on(mbr.read_blocks(0, &mut out, ReadContext::FOREGROUND)).expect("read first lba");
+        assert_eq!(&out[..], &partition_data[..LBA_SIZE]);
+    }
+
+    #[test]
+    fn mbr_reader_rejects_invalid_explicit_source_lba_size() {
+        let (disk, _, _) = build_test_mbr_disk();
+        let reader = FakeReader {
+            block_size: TEST_BLOCK_SIZE as u32,
+            data: disk,
+        };
+        let config = MbrBlockReaderConfig::new(MbrPartitionSelector::index(0), 512)
+            .with_source_lba_size(513);
+
+        let err = match block_on(MbrBlockReader::open_with_config(reader, config)) {
+            Ok(_) => panic!("non-pow2 source_lba_size should fail validate"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), GibbloxErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn mbr_reader_config_identity_includes_source_lba_size() {
+        let plain = MbrBlockReaderConfig::new(MbrPartitionSelector::index(0), 512)
+            .with_source_identity("upstream");
+        let mut s_plain = String::new();
+        plain.write_identity(&mut s_plain).unwrap();
+
+        let with_lba = MbrBlockReaderConfig::new(MbrPartitionSelector::index(0), 512)
+            .with_source_identity("upstream")
+            .with_source_lba_size(4096);
+        let mut s_with = String::new();
+        with_lba.write_identity(&mut s_with).unwrap();
+
+        assert_ne!(s_plain, s_with);
+        assert!(s_with.contains("source_lba_size=4096"));
+        assert!(!s_plain.contains("source_lba_size"));
     }
 
     fn build_test_mbr_disk() -> (

--- a/crates/gibblox-pipeline/src/bin.rs
+++ b/crates/gibblox-pipeline/src/bin.rs
@@ -12,8 +12,12 @@ use crate::{
 };
 
 pub const PIPELINE_BIN_MAGIC: [u8; 8] = *b"GBXPIPE0";
-pub const PIPELINE_BIN_FORMAT_VERSION: u16 = 2;
+pub const PIPELINE_BIN_FORMAT_VERSION: u16 = 3;
 pub const PIPELINE_BIN_HEADER_LEN: usize = PIPELINE_BIN_MAGIC.len() + 2;
+
+/// Format versions this build can decode. Newer code adds optional fields and
+/// older payloads deserialize against the older mirror struct, then translate.
+pub const PIPELINE_BIN_SUPPORTED_VERSIONS: &[u16] = &[2, 3];
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum PipelineSourceBin {
@@ -42,6 +46,7 @@ pub enum PipelineSourceBin {
     Mbr {
         partuuid: Option<String>,
         index: Option<u32>,
+        lba_size: Option<u32>,
         source: Box<PipelineSourceBin>,
         content: Option<PipelineSourceContent>,
     },
@@ -49,9 +54,113 @@ pub enum PipelineSourceBin {
         partlabel: Option<String>,
         partuuid: Option<String>,
         index: Option<u32>,
+        lba_size: Option<u32>,
         source: Box<PipelineSourceBin>,
         content: Option<PipelineSourceContent>,
     },
+}
+
+/// Wire-compatible mirror of [`PipelineSourceBin`] for format version 2
+/// (before the `lba_size` field was introduced). Decoded payloads are
+/// translated to the current shape with `lba_size: None`. The `Serialize`
+/// impl exists so tests can synthesize v2 payloads on the fly.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) enum PipelineSourceBinV2 {
+    Casync {
+        index: String,
+        chunk_store: Option<String>,
+        content: Option<PipelineSourceContent>,
+    },
+    Http {
+        url: String,
+        cors_safelisted_mode: bool,
+        content: Option<PipelineSourceContent>,
+    },
+    File {
+        path: String,
+        content: Option<PipelineSourceContent>,
+    },
+    Xz {
+        source: Box<PipelineSourceBinV2>,
+        content: Option<PipelineSourceContent>,
+    },
+    AndroidSparseImg {
+        source: Box<PipelineSourceBinV2>,
+        content: Option<PipelineSourceContent>,
+    },
+    Mbr {
+        partuuid: Option<String>,
+        index: Option<u32>,
+        source: Box<PipelineSourceBinV2>,
+        content: Option<PipelineSourceContent>,
+    },
+    Gpt {
+        partlabel: Option<String>,
+        partuuid: Option<String>,
+        index: Option<u32>,
+        source: Box<PipelineSourceBinV2>,
+        content: Option<PipelineSourceContent>,
+    },
+}
+
+impl From<PipelineSourceBinV2> for PipelineSourceBin {
+    fn from(v2: PipelineSourceBinV2) -> Self {
+        match v2 {
+            PipelineSourceBinV2::Casync {
+                index,
+                chunk_store,
+                content,
+            } => Self::Casync {
+                index,
+                chunk_store,
+                content,
+            },
+            PipelineSourceBinV2::Http {
+                url,
+                cors_safelisted_mode,
+                content,
+            } => Self::Http {
+                url,
+                cors_safelisted_mode,
+                content,
+            },
+            PipelineSourceBinV2::File { path, content } => Self::File { path, content },
+            PipelineSourceBinV2::Xz { source, content } => Self::Xz {
+                source: Box::new(PipelineSourceBin::from(*source)),
+                content,
+            },
+            PipelineSourceBinV2::AndroidSparseImg { source, content } => Self::AndroidSparseImg {
+                source: Box::new(PipelineSourceBin::from(*source)),
+                content,
+            },
+            PipelineSourceBinV2::Mbr {
+                partuuid,
+                index,
+                source,
+                content,
+            } => Self::Mbr {
+                partuuid,
+                index,
+                lba_size: None,
+                source: Box::new(PipelineSourceBin::from(*source)),
+                content,
+            },
+            PipelineSourceBinV2::Gpt {
+                partlabel,
+                partuuid,
+                index,
+                source,
+                content,
+            } => Self::Gpt {
+                partlabel,
+                partuuid,
+                index,
+                lba_size: None,
+                source: Box::new(PipelineSourceBin::from(*source)),
+                content,
+            },
+        }
+    }
 }
 
 impl From<PipelineSource> for PipelineSourceBin {
@@ -90,12 +199,14 @@ impl From<PipelineSource> for PipelineSourceBin {
                     PipelineSourceMbr {
                         partuuid,
                         index,
+                        lba_size,
                         source,
                         content,
                     },
             }) => Self::Mbr {
                 partuuid,
                 index,
+                lba_size,
                 source: Box::new(PipelineSourceBin::from(*source)),
                 content,
             },
@@ -105,6 +216,7 @@ impl From<PipelineSource> for PipelineSourceBin {
                         partlabel,
                         partuuid,
                         index,
+                        lba_size,
                         source,
                         content,
                     },
@@ -112,6 +224,7 @@ impl From<PipelineSource> for PipelineSourceBin {
                 partlabel,
                 partuuid,
                 index,
+                lba_size,
                 source: Box::new(PipelineSourceBin::from(*source)),
                 content,
             },
@@ -161,12 +274,14 @@ impl From<PipelineSourceBin> for PipelineSource {
             PipelineSourceBin::Mbr {
                 partuuid,
                 index,
+                lba_size,
                 source,
                 content,
             } => Self::Mbr(PipelineSourceMbrSource {
                 mbr: PipelineSourceMbr {
                     partuuid,
                     index,
+                    lba_size,
                     source: Box::new(PipelineSource::from(*source)),
                     content,
                 },
@@ -175,6 +290,7 @@ impl From<PipelineSourceBin> for PipelineSource {
                 partlabel,
                 partuuid,
                 index,
+                lba_size,
                 source,
                 content,
             } => Self::Gpt(PipelineSourceGptSource {
@@ -182,6 +298,7 @@ impl From<PipelineSourceBin> for PipelineSource {
                     partlabel,
                     partuuid,
                     index,
+                    lba_size,
                     source: Box::new(PipelineSource::from(*source)),
                     content,
                 },

--- a/crates/gibblox-pipeline/src/lib.rs
+++ b/crates/gibblox-pipeline/src/lib.rs
@@ -82,12 +82,16 @@ pub fn decode_pipeline(bytes: &[u8]) -> Result<PipelineSource, PipelineCodecErro
     let Some(format_version) = pipeline_bin_header_version(bytes) else {
         return Err(PipelineCodecError::InvalidMagic);
     };
-    if format_version != PIPELINE_BIN_FORMAT_VERSION {
-        return Err(PipelineCodecError::UnsupportedFormatVersion(format_version));
-    }
 
     let payload = &bytes[PIPELINE_BIN_HEADER_LEN..];
-    let pipeline: PipelineSourceBin = postcard::from_bytes(payload)?;
+    let pipeline = match format_version {
+        3 => postcard::from_bytes::<PipelineSourceBin>(payload)?,
+        2 => {
+            let v2: bin::PipelineSourceBinV2 = postcard::from_bytes(payload)?;
+            PipelineSourceBin::from(v2)
+        }
+        _ => return Err(PipelineCodecError::UnsupportedFormatVersion(format_version)),
+    };
     Ok(PipelineSource::from(pipeline))
 }
 
@@ -428,6 +432,7 @@ fn write_pipeline_identity(source: &PipelineSource, out: &mut dyn fmt::Write) ->
             out.write_str("mbr{")?;
             write_opt_string_field(out, "partuuid", source.mbr.partuuid.as_deref())?;
             write_opt_u32_field(out, "index", source.mbr.index)?;
+            write_opt_u32_field(out, "lba_size", source.mbr.lba_size)?;
             out.write_str("source=")?;
             write_pipeline_identity(source.mbr.source.as_ref(), out)?;
             out.write_str("}")
@@ -437,6 +442,7 @@ fn write_pipeline_identity(source: &PipelineSource, out: &mut dyn fmt::Write) ->
             write_opt_string_field(out, "partlabel", source.gpt.partlabel.as_deref())?;
             write_opt_string_field(out, "partuuid", source.gpt.partuuid.as_deref())?;
             write_opt_u32_field(out, "index", source.gpt.index)?;
+            write_opt_u32_field(out, "lba_size", source.gpt.lba_size)?;
             out.write_str("source=")?;
             write_pipeline_identity(source.gpt.source.as_ref(), out)?;
             out.write_str("}")
@@ -649,6 +655,8 @@ pub struct PipelineSourceMbr {
     pub partuuid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub index: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lba_size: Option<u32>,
     #[serde(flatten)]
     pub source: Box<PipelineSource>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -663,6 +671,8 @@ enum PipelineSourceMbrValue {
         partuuid: Option<String>,
         #[serde(default)]
         index: Option<u32>,
+        #[serde(default)]
+        lba_size: Option<u32>,
         #[serde(flatten)]
         source: Box<PipelineSource>,
         #[serde(default)]
@@ -673,6 +683,8 @@ enum PipelineSourceMbrValue {
         partuuid: Option<String>,
         #[serde(default)]
         index: Option<u32>,
+        #[serde(default)]
+        lba_size: Option<u32>,
         source: Box<PipelineSource>,
         #[serde(default)]
         content: Option<PipelineSourceContent>,
@@ -688,17 +700,20 @@ where
         PipelineSourceMbrValue::Flatten {
             partuuid,
             index,
+            lba_size,
             source,
             content,
         }
         | PipelineSourceMbrValue::Source {
             partuuid,
             index,
+            lba_size,
             source,
             content,
         } => PipelineSourceMbr {
             partuuid,
             index,
+            lba_size,
             source,
             content,
         },
@@ -720,6 +735,8 @@ pub struct PipelineSourceGpt {
     pub partuuid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub index: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lba_size: Option<u32>,
     #[serde(flatten)]
     pub source: Box<PipelineSource>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -736,6 +753,8 @@ enum PipelineSourceGptValue {
         partuuid: Option<String>,
         #[serde(default)]
         index: Option<u32>,
+        #[serde(default)]
+        lba_size: Option<u32>,
         #[serde(flatten)]
         source: Box<PipelineSource>,
         #[serde(default)]
@@ -748,6 +767,8 @@ enum PipelineSourceGptValue {
         partuuid: Option<String>,
         #[serde(default)]
         index: Option<u32>,
+        #[serde(default)]
+        lba_size: Option<u32>,
         source: Box<PipelineSource>,
         #[serde(default)]
         content: Option<PipelineSourceContent>,
@@ -764,6 +785,7 @@ where
             partlabel,
             partuuid,
             index,
+            lba_size,
             source,
             content,
         }
@@ -771,12 +793,14 @@ where
             partlabel,
             partuuid,
             index,
+            lba_size,
             source,
             content,
         } => PipelineSourceGpt {
             partlabel,
             partuuid,
             index,
+            lba_size,
             source,
             content,
         },
@@ -813,6 +837,7 @@ mod tests {
                 partlabel: None,
                 partuuid: Some(String::from("31b7f334-6df8-4f95-b4b0-c8653f8f8fbf")),
                 index: None,
+                lba_size: None,
                 source: Box::new(PipelineSource::AndroidSparseImg(
                     PipelineSourceAndroidSparseImgSource {
                         android_sparseimg: PipelineSourceAndroidSparseImg {
@@ -889,6 +914,7 @@ gpt:
             mbr: PipelineSourceMbr {
                 partuuid: None,
                 index: None,
+                lba_size: None,
                 source: Box::new(PipelineSource::Http(PipelineSourceHttpSource {
                     http: String::from("https://cdn.example.invalid/rootfs.img"),
                     cors_safelisted_mode: false,
@@ -912,6 +938,7 @@ gpt:
                 partlabel: Some(String::from("  ")),
                 partuuid: None,
                 index: None,
+                lba_size: None,
                 source: Box::new(PipelineSource::Http(PipelineSourceHttpSource {
                     http: String::from("https://cdn.example.invalid/rootfs.img"),
                     cors_safelisted_mode: false,
@@ -959,12 +986,12 @@ gpt:
     fn rejects_unsupported_format_version() {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&crate::bin::PIPELINE_BIN_MAGIC);
-        bytes.extend_from_slice(&3u16.to_le_bytes());
+        bytes.extend_from_slice(&99u16.to_le_bytes());
 
         let err = decode_pipeline(&bytes).expect_err("unsupported version should fail");
         assert!(matches!(
             err,
-            PipelineCodecError::UnsupportedFormatVersion(3)
+            PipelineCodecError::UnsupportedFormatVersion(99)
         ));
     }
 
@@ -977,7 +1004,43 @@ gpt:
         });
         let bytes = encode_pipeline(&source).expect("encode pipeline");
 
-        assert_eq!(pipeline_bin_header_version(&bytes), Some(2));
+        assert_eq!(pipeline_bin_header_version(&bytes), Some(3));
+    }
+
+    #[test]
+    fn decodes_v2_payload_with_lba_size_none() {
+        // Build a v2-shaped GPT payload by hand: encode it via the v2 mirror
+        // struct in `bin`, slap on the v=2 header, then decode through the
+        // public path and assert the lba_size field defaults to None.
+        let v2 = crate::bin::PipelineSourceBinV2::Gpt {
+            partlabel: None,
+            partuuid: Some(String::from("31b7f334-6df8-4f95-b4b0-c8653f8f8fbf")),
+            index: None,
+            source: Box::new(crate::bin::PipelineSourceBinV2::Http {
+                url: String::from("https://cdn.example.invalid/rootfs.img"),
+                cors_safelisted_mode: false,
+                content: Some(sample_content()),
+            }),
+            content: None,
+        };
+        let payload = postcard::to_allocvec(&v2).expect("encode v2");
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&crate::bin::PIPELINE_BIN_MAGIC);
+        bytes.extend_from_slice(&2u16.to_le_bytes());
+        bytes.extend_from_slice(&payload);
+
+        let decoded = decode_pipeline(&bytes).expect("decode v2 payload");
+        match decoded {
+            PipelineSource::Gpt(g) => {
+                assert_eq!(g.gpt.lba_size, None);
+                assert_eq!(
+                    g.gpt.partuuid.as_deref(),
+                    Some("31b7f334-6df8-4f95-b4b0-c8653f8f8fbf")
+                );
+            }
+            other => panic!("expected gpt, got {other:?}"),
+        }
     }
 
     #[test]
@@ -987,6 +1050,7 @@ gpt:
                 partlabel: None,
                 partuuid: Some(String::from("31b7f334-6df8-4f95-b4b0-c8653f8f8fbf")),
                 index: None,
+                lba_size: None,
                 source: Box::new(PipelineSource::Xz(PipelineSourceXzSource {
                     xz: Box::new(PipelineSource::Http(PipelineSourceHttpSource {
                         http: String::from("https://cdn.example.invalid/device.img.xz"),

--- a/crates/gibblox-pipeline/src/materialize_std.rs
+++ b/crates/gibblox-pipeline/src/materialize_std.rs
@@ -15,11 +15,11 @@ use gibblox_casync_std::{
 };
 use gibblox_core::{
     AlignedByteReader, BlockByteReader, BlockReader, ByteReader, GptBlockReader,
-    GptPartitionSelector,
+    GptBlockReaderConfig, GptPartitionSelector,
 };
 use gibblox_file::FileReader;
 use gibblox_http::{HttpReader, HttpReaderConfig};
-use gibblox_mbr::{MbrBlockReader, MbrPartitionSelector};
+use gibblox_mbr::{MbrBlockReader, MbrBlockReaderConfig, MbrPartitionSelector};
 use gibblox_xz::XzBlockReader;
 use tracing::warn;
 use url::Url;
@@ -123,7 +123,11 @@ pub(crate) fn open_pipeline_source<'a>(
                 };
 
                 let upstream = open_pipeline_source(source.mbr.source.as_ref(), opts).await?;
-                let reader = MbrBlockReader::new(upstream, selector, opts.image_block_size)
+                let mut config = MbrBlockReaderConfig::new(selector, opts.image_block_size);
+                if let Some(lba_size) = source.mbr.lba_size {
+                    config = config.with_source_lba_size(lba_size);
+                }
+                let reader = MbrBlockReader::open_with_config(upstream, config)
                     .await
                     .map_err(|err| anyhow!("open mbr reader: {err}"))?;
                 Ok(Arc::new(reader) as DynBlockReader)
@@ -140,7 +144,11 @@ pub(crate) fn open_pipeline_source<'a>(
                 };
 
                 let upstream = open_pipeline_source(source.gpt.source.as_ref(), opts).await?;
-                let reader = GptBlockReader::new(upstream, selector, opts.image_block_size)
+                let mut config = GptBlockReaderConfig::new(selector, opts.image_block_size);
+                if let Some(lba_size) = source.gpt.lba_size {
+                    config = config.with_source_lba_size(lba_size);
+                }
+                let reader = GptBlockReader::open_with_config(upstream, config)
                     .await
                     .map_err(|err| anyhow!("open gpt reader: {err}"))?;
                 Ok(Arc::new(reader) as DynBlockReader)

--- a/crates/gibblox-pipeline/src/materialize_web.rs
+++ b/crates/gibblox-pipeline/src/materialize_web.rs
@@ -9,7 +9,7 @@ use gibblox_casync::{CasyncBlockReader, CasyncReaderConfig};
 use gibblox_casync_web::{WebCasyncChunkStore, WebCasyncChunkStoreConfig, WebCasyncIndexSource};
 use gibblox_core::{
     AlignedByteReader, BlockByteReader, BlockReader, ByteReader, GibbloxError, GibbloxErrorKind,
-    GibbloxResult, GptBlockReader, GptPartitionSelector,
+    GibbloxResult, GptBlockReader, GptBlockReaderConfig, GptPartitionSelector,
 };
 use gibblox_http::{HttpReader, HttpReaderConfig};
 use gibblox_mbr::{MbrBlockReader, MbrBlockReaderConfig, MbrPartitionSelector};
@@ -89,8 +89,11 @@ fn resolve_pipeline_source<'a>(
             PipelineSource::Mbr(source) => {
                 let upstream = resolve_pipeline_source(source.mbr.source.as_ref(), opts).await?;
                 let selector = mbr_selector(source)?;
-                let config = MbrBlockReaderConfig::new(selector, upstream.block_size())
+                let mut config = MbrBlockReaderConfig::new(selector, upstream.block_size())
                     .with_source_identity(source_identity(source.mbr.source.as_ref()));
+                if let Some(lba_size) = source.mbr.lba_size {
+                    config = config.with_source_lba_size(lba_size);
+                }
                 let reader = MbrBlockReader::open_with_config(upstream, config).await?;
                 let reader: Arc<dyn BlockReader> = Arc::new(reader);
                 Ok(reader)
@@ -99,7 +102,12 @@ fn resolve_pipeline_source<'a>(
                 let upstream = resolve_pipeline_source(source.gpt.source.as_ref(), opts).await?;
                 let selector = gpt_selector(source)?;
                 let block_size = upstream.block_size();
-                let reader = GptBlockReader::new(upstream, selector, block_size).await?;
+                let mut config = GptBlockReaderConfig::new(selector, block_size)
+                    .with_source_identity(source_identity(source.gpt.source.as_ref()));
+                if let Some(lba_size) = source.gpt.lba_size {
+                    config = config.with_source_lba_size(lba_size);
+                }
+                let reader = GptBlockReader::open_with_config(upstream, config).await?;
                 let reader: Arc<dyn BlockReader> = Arc::new(reader);
                 Ok(reader)
             }

--- a/crates/gibblox-schema/src/lib.rs
+++ b/crates/gibblox-schema/src/lib.rs
@@ -90,31 +90,26 @@ impl fmt::Display for PipelineHintsValidationError {
             Self::EmptyIdentity => write!(f, "pipeline hint entry has an empty pipeline_identity"),
             Self::DuplicateIdentity { pipeline_identity } => write!(
                 f,
-                "duplicate pipeline hint identity '{}' is not allowed",
-                pipeline_identity
+                "duplicate pipeline hint identity '{pipeline_identity}' is not allowed"
             ),
             Self::UnsortedIdentity {
                 previous_identity,
                 pipeline_identity,
             } => write!(
                 f,
-                "pipeline hint identities must be sorted; '{}' appears after '{}'",
-                pipeline_identity, previous_identity
+                "pipeline hint identities must be sorted; '{pipeline_identity}' appears after '{previous_identity}'"
             ),
             Self::EmptyHints { pipeline_identity } => write!(
                 f,
-                "pipeline hint entry '{}' must contain at least one hint",
-                pipeline_identity
+                "pipeline hint entry '{pipeline_identity}' must contain at least one hint"
             ),
             Self::DuplicateHintTypeAndroidSparseIndex { pipeline_identity } => write!(
                 f,
-                "pipeline hint entry '{}' contains duplicate AndroidSparseIndex hints",
-                pipeline_identity
+                "pipeline hint entry '{pipeline_identity}' contains duplicate AndroidSparseIndex hints"
             ),
             Self::DuplicateHintTypeContentDigest { pipeline_identity } => write!(
                 f,
-                "pipeline hint entry '{}' contains duplicate ContentDigest hints",
-                pipeline_identity
+                "pipeline hint entry '{pipeline_identity}' contains duplicate ContentDigest hints"
             ),
         }
     }

--- a/crates/gobblytes-core/src/lib.rs
+++ b/crates/gobblytes-core/src/lib.rs
@@ -207,7 +207,7 @@ where
             apply_path_target(&mut resolved, &link_target)?;
 
             let mut rewritten = resolved.into_iter().collect::<VecDeque<_>>();
-            rewritten.extend(remaining.into_iter());
+            rewritten.extend(remaining);
             remaining = rewritten;
             resolved = Vec::new();
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.88.0"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
GptBlockReader and MbrBlockReader previously inferred their source LBA size from the upstream's reported `block_size()`. This conflates two unrelated concepts: the encoding-internal chunk granularity (e.g. an Android sparse image's `blk_sz`, typically 4096) and the LBA size of the contained virtual disk (often 512). When they didn't match -- for example postmarketOS images for any device whose
`deviceinfo_rootfs_image_sector_size` is 512 -- the GPT reader looked for `EFI PART` at the wrong byte offset and failed to open the image.

Decouple the two:

- Add `source_lba_size: Option<u32>` to `GptBlockReaderConfig` and `MbrBlockReaderConfig`. When set, the reader bridges via the existing `WindowBlockReader` and addresses upstream LBAs at the configured size instead of inheriting from `source.block_size()`. Identity strings include the override so cache keys differ when it differs.
- For GPT, when no override is set, auto-probe the upstream's reported size, then 512, then 4096, and use the first candidate that exposes a valid `EFI PART` signature at LBA1. Most callers need no config. MBR keeps the current 512-byte default; auto-probe is a follow-up.
- Surface `lba_size: Option<u32>` on `PipelineSourceGpt` and `PipelineSourceMbr` and plumb it through `materialize_std` and `materialize_web` via `open_with_config`.
- Bump the binary pipeline format to v3, add a v2-shape decode shim that maps to `lba_size: None`. v2 payloads continue to decode and benefit from the new auto-probe behaviour.